### PR TITLE
Add AlarmKit Fajr/Sunrise wake-up alarm (iOS 26+) — closes #13

### DIFF
--- a/Athan Utility.xcodeproj/project.pbxproj
+++ b/Athan Utility.xcodeproj/project.pbxproj
@@ -191,6 +191,15 @@
 		3DF79CD82F45663E00E01FD2 /* SuhoorActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF79CD42F4564F800E01FD2 /* SuhoorActivityAttributes.swift */; };
 		3DF79CDA2F45668D00E01FD2 /* SuhoorActivityTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF79CD22F4564B700E01FD2 /* SuhoorActivityTrigger.swift */; };
 		3DF79CDB2F45668D00E01FD2 /* SuhoorActivityTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF79CD22F4564B700E01FD2 /* SuhoorActivityTrigger.swift */; };
+		E4F66D792F9AED0200A81E1C /* FajrAlarmSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F66D782F9AED0200A81E1C /* FajrAlarmSettingsView.swift */; };
+		E4F66D7A2F9AED0200A81E1C /* FajrAlarmSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F66D772F9AED0200A81E1C /* FajrAlarmSettings.swift */; };
+		E4F66D7B2F9AED0200A81E1C /* FajrAlarmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F66D762F9AED0200A81E1C /* FajrAlarmManager.swift */; };
+		E4F66D7C2F9AED0200A81E1C /* FajrAlarmSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F66D772F9AED0200A81E1C /* FajrAlarmSettings.swift */; };
+		E4F66D7D2F9AED0200A81E1C /* FajrAlarmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F66D762F9AED0200A81E1C /* FajrAlarmManager.swift */; };
+		E4F66D7E2F9AED0200A81E1C /* FajrAlarmSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F66D772F9AED0200A81E1C /* FajrAlarmSettings.swift */; };
+		E4F66D7F2F9AED0200A81E1C /* FajrAlarmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F66D762F9AED0200A81E1C /* FajrAlarmManager.swift */; };
+		E4F66D802F9AED0200A81E1C /* FajrAlarmSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F66D772F9AED0200A81E1C /* FajrAlarmSettings.swift */; };
+		E4F66D812F9AED0200A81E1C /* FajrAlarmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F66D762F9AED0200A81E1C /* FajrAlarmManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -465,6 +474,9 @@
 		3DF79CD02F45364D00E01FD2 /* SuhoorActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuhoorActivity.swift; sourceTree = "<group>"; };
 		3DF79CD22F4564B700E01FD2 /* SuhoorActivityTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuhoorActivityTrigger.swift; sourceTree = "<group>"; };
 		3DF79CD42F4564F800E01FD2 /* SuhoorActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuhoorActivityAttributes.swift; sourceTree = "<group>"; };
+		E4F66D762F9AED0200A81E1C /* FajrAlarmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FajrAlarmManager.swift; sourceTree = "<group>"; };
+		E4F66D772F9AED0200A81E1C /* FajrAlarmSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FajrAlarmSettings.swift; sourceTree = "<group>"; };
+		E4F66D782F9AED0200A81E1C /* FajrAlarmSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FajrAlarmSettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -586,6 +598,9 @@
 				3D07DA7E1BDC58B60001EFE4 /* AppDelegate.swift */,
 				3D4AC194251D94BE00B2D41D /* SceneDelegate.swift */,
 				3D16F10A2560859D00C78B12 /* AthanManager.swift */,
+				E4F66D762F9AED0200A81E1C /* FajrAlarmManager.swift */,
+				E4F66D772F9AED0200A81E1C /* FajrAlarmSettings.swift */,
+				E4F66D782F9AED0200A81E1C /* FajrAlarmSettingsView.swift */,
 				3DCAB77B25AEC40D0075801B /* WatchSessionDelegate.swift */,
 				3DCAB79325AEC5080075801B /* PhoneWatchDelegate.swift */,
 				3DBAE55F25B15E26008E87E9 /* CommonWatchCommunication.swift */,
@@ -1252,6 +1267,9 @@
 				3D727FC82BCF0417003D40A2 /* ActivityIndicator.swift in Sources */,
 				3D0789C6259C5DAB0047DD00 /* PrivacyInfoView.swift in Sources */,
 				3D33FB9029C9E2B600F9CDD9 /* CalendarExport.swift in Sources */,
+				E4F66D792F9AED0200A81E1C /* FajrAlarmSettingsView.swift in Sources */,
+				E4F66D7A2F9AED0200A81E1C /* FajrAlarmSettings.swift in Sources */,
+				E4F66D7B2F9AED0200A81E1C /* FajrAlarmManager.swift in Sources */,
 				3D6105042572D04E00C1D067 /* SettingsView.swift in Sources */,
 				3D67E05E2ADF3E010020B55B /* ShareSheet.swift in Sources */,
 				3D07897A259A6E5E0047DD00 /* ColorsView.swift in Sources */,
@@ -1301,6 +1319,8 @@
 				3DDE2E192F4579A10099BBE9 /* TertiaryAthanWidget.swift in Sources */,
 				3D73EC3B25717ED20010C47D /* PrayerSymbol.swift in Sources */,
 				3D73EBF1257027230010C47D /* SettingsModels.swift in Sources */,
+				E4F66D7C2F9AED0200A81E1C /* FajrAlarmSettings.swift in Sources */,
+				E4F66D7D2F9AED0200A81E1C /* FajrAlarmManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1326,6 +1346,8 @@
 				3DB56CF12283682800B9F738 /* PrayerType.swift in Sources */,
 				3DB56CF4228369A200B9F738 /* Global.swift in Sources */,
 				3DBAE57025B15E2F008E87E9 /* CommonWatchCommunication.swift in Sources */,
+				E4F66D7E2F9AED0200A81E1C /* FajrAlarmSettings.swift in Sources */,
+				E4F66D7F2F9AED0200A81E1C /* FajrAlarmManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1355,6 +1377,8 @@
 				3DEE3A9425A6A18400DC7331 /* AthanManager.swift in Sources */,
 				3DEE3A7225A6A04D00DC7331 /* NotificationView.swift in Sources */,
 				3DCAB78B25AEC4230075801B /* WatchSessionDelegate.swift in Sources */,
+				E4F66D802F9AED0200A81E1C /* FajrAlarmSettings.swift in Sources */,
+				E4F66D812F9AED0200A81E1C /* FajrAlarmManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Athan Utility/AppDelegate.swift
+++ b/Athan Utility/AppDelegate.swift
@@ -32,11 +32,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         return true
     }
 
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Request another refresh whenever we're backgrounded so the rolling
-        // AlarmKit window can be topped up while the app is suspended.
-        scheduleFajrAlarmRefresh()
-    }
+    // Note: `applicationDidEnterBackground` is not invoked on scene-based
+    // apps (this project has `UIApplicationSceneManifest` in Info.plist),
+    // so the background-refresh top-up is wired from
+    // `SceneDelegate.sceneDidEnterBackground` instead.
 
     // MARK: - AlarmKit background refresh
 
@@ -55,7 +54,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
     }
 
-    private func scheduleFajrAlarmRefresh() {
+    // Internal so SceneDelegate can re-submit on backgrounding.
+    func scheduleFajrAlarmRefresh() {
         let request = BGAppRefreshTaskRequest(identifier: AppDelegate.fajrAlarmRefreshTaskID)
         // Refresh at most every ~6 hours. System decides the actual firing.
         request.earliestBeginDate = Date(timeIntervalSinceNow: 6 * 60 * 60)
@@ -71,23 +71,41 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // doesn't drop the rolling refresh.
         scheduleFajrAlarmRefresh()
 
-        // Reload latest persisted settings from the app group. This kicks off
-        // its own `FajrAlarmManager.syncAlarms()` internally (gated on the
-        // main-app bundle); our explicit `syncAlarms()` below chains after
-        // that one and is the Task we actually await before marking the
-        // BGTask complete, so the rolling AlarmKit window is guaranteed to
-        // be rebuilt before the OS suspends us.
+        // Reload latest persisted settings from the app group. `reloadSettingsAndNotifications`
+        // also calls `syncAlarms()` when the user has a non-default location;
+        // our explicit `syncAlarms()` below is unconditional for the main-app
+        // bundle (and chains onto any prior one), and is the Task we actually
+        // await before marking the BGTask complete so the rolling AlarmKit
+        // window is guaranteed to be rebuilt before the OS suspends us.
         AthanManager.shared.reloadSettingsAndNotifications()
         let syncTask = FajrAlarmManager.shared.syncAlarms()
 
+        // `setTaskCompleted(success:)` must be called exactly once per
+        // BGAppRefreshTask. Both `expirationHandler` and the awaiting Task
+        // below can fire (if the OS expires us while the sync's in-flight
+        // scheduling continues — cooperative cancellation doesn't abort
+        // AlarmKit calls immediately), so funnel both paths through a
+        // guarded completion. NSLock because Apple doesn't contractually
+        // guarantee `expirationHandler` runs on the same queue as the
+        // `using:` queue passed to `register`.
+        let completionLock = NSLock()
+        var hasCompleted = false
+        let complete: (Bool) -> Void = { success in
+            completionLock.lock()
+            defer { completionLock.unlock() }
+            guard !hasCompleted else { return }
+            hasCompleted = true
+            task.setTaskCompleted(success: success)
+        }
+
         task.expirationHandler = {
             syncTask.cancel()
-            task.setTaskCompleted(success: false)
+            complete(false)
         }
 
         Task { @MainActor in
             await syncTask.value
-            task.setTaskCompleted(success: true)
+            complete(true)
         }
     }
     

--- a/Athan Utility/AppDelegate.swift
+++ b/Athan Utility/AppDelegate.swift
@@ -11,18 +11,70 @@
 import UIKit
 import UserNotifications
 import WatchConnectivity
+import BackgroundTasks
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     var window: UIWindow?
-    
+
+    // Identifier must match BGTaskSchedulerPermittedIdentifiers in Info.plist.
+    static let fajrAlarmRefreshTaskID = "com.omaralejel.Athan-Utility.fajrAlarmRefresh"
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         if WCSession.isSupported() {
             WCSession.default.delegate = PhoneWatchDelegate.shared
             WCSession.default.activate()
         }
-        
+
+        registerFajrAlarmRefreshTask()
+        scheduleFajrAlarmRefresh()
+
         return true
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Request another refresh whenever we're backgrounded so the rolling
+        // AlarmKit window can be topped up while the app is suspended.
+        scheduleFajrAlarmRefresh()
+    }
+
+    // MARK: - AlarmKit background refresh
+
+    private func registerFajrAlarmRefreshTask() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: AppDelegate.fajrAlarmRefreshTaskID,
+            using: nil
+        ) { task in
+            self.handleFajrAlarmRefresh(task: task as! BGAppRefreshTask)
+        }
+    }
+
+    private func scheduleFajrAlarmRefresh() {
+        let request = BGAppRefreshTaskRequest(identifier: AppDelegate.fajrAlarmRefreshTaskID)
+        // Refresh at most every ~6 hours. System decides the actual firing.
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 6 * 60 * 60)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            print("AppDelegate: could not submit Fajr alarm refresh task: \(error)")
+        }
+    }
+
+    private func handleFajrAlarmRefresh(task: BGAppRefreshTask) {
+        // Always reschedule for the next window first so a slow completion
+        // doesn't drop the rolling refresh.
+        scheduleFajrAlarmRefresh()
+
+        task.expirationHandler = {
+            // syncAlarms() is fire-and-forget; best we can do is mark unfinished.
+            task.setTaskCompleted(success: false)
+        }
+
+        // Reload latest persisted settings from the app group, then sync.
+        AthanManager.shared.reloadSettingsAndNotifications()
+        FajrAlarmManager.shared.syncAlarms()
+
+        task.setTaskCompleted(success: true)
     }
     
     // launching from a force-press shortcut item

--- a/Athan Utility/AppDelegate.swift
+++ b/Athan Utility/AppDelegate.swift
@@ -41,9 +41,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // MARK: - AlarmKit background refresh
 
     private func registerFajrAlarmRefreshTask() {
+        // Run the launch handler on the main queue. `reloadSettingsAndNotifications`
+        // mutates `@Published` state on `ObservableAthanManager` and touches
+        // timers / `WidgetCenter.shared`, both of which require the main thread.
+        // Passing `nil` here would put the handler on a system background
+        // queue, triggering Combine's "Publishing changes from background
+        // threads is not allowed" runtime issue.
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: AppDelegate.fajrAlarmRefreshTaskID,
-            using: nil
+            using: .main
         ) { task in
             self.handleFajrAlarmRefresh(task: task as! BGAppRefreshTask)
         }
@@ -65,16 +71,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // doesn't drop the rolling refresh.
         scheduleFajrAlarmRefresh()
 
+        // Reload latest persisted settings from the app group. This kicks off
+        // its own `FajrAlarmManager.syncAlarms()` internally (gated on the
+        // main-app bundle); our explicit `syncAlarms()` below chains after
+        // that one and is the Task we actually await before marking the
+        // BGTask complete, so the rolling AlarmKit window is guaranteed to
+        // be rebuilt before the OS suspends us.
+        AthanManager.shared.reloadSettingsAndNotifications()
+        let syncTask = FajrAlarmManager.shared.syncAlarms()
+
         task.expirationHandler = {
-            // syncAlarms() is fire-and-forget; best we can do is mark unfinished.
+            syncTask.cancel()
             task.setTaskCompleted(success: false)
         }
 
-        // Reload latest persisted settings from the app group, then sync.
-        AthanManager.shared.reloadSettingsAndNotifications()
-        FajrAlarmManager.shared.syncAlarms()
-
-        task.setTaskCompleted(success: true)
+        Task { @MainActor in
+            await syncTask.value
+            task.setTaskCompleted(success: true)
+        }
     }
     
     // launching from a force-press shortcut item

--- a/Athan Utility/AthanManager.swift
+++ b/Athan Utility/AthanManager.swift
@@ -473,6 +473,14 @@ extension AthanManager {
                                      noteSettings: notificationSettings,
                                      shortLocationName: locationSettings.locationName)
             resetWidgets() // should happen when any of our settings change
+
+            // Refresh the rolling AlarmKit window (iOS 26+). Gated on the
+            // main-app bundle so widget / Siri / watch extension contexts
+            // don't each try to schedule their own alarms. No-op pre-26 or
+            // when the user hasn't enabled the feature.
+            if let bundleID = Bundle.main.bundleIdentifier, bundleID == "com.omaralejel.Athan-Utility" {
+                FajrAlarmManager.shared.syncAlarms()
+            }
             
             if #available(iOS 16.2, *) {
 //                Task {

--- a/Athan Utility/ClockView.swift
+++ b/Athan Utility/ClockView.swift
@@ -279,11 +279,17 @@ class ClockView: UIView {
         
         let totaHeight = fittingRect.size.height
         let totalWidth = longWidth
-        
-        minutesLayer.anchorPoint = CGPoint(x: 0.5, y: ((totaHeight - (shortWidth / 2)) / totaHeight))
-        minutesLayer.frame.origin = CGPoint(x: (width / 2) - (totalWidth / 2), y: (height / 2) - (totaHeight - (shortWidth / 2)))
-        
-        
+
+        // Split these out so the Swift type-checker doesn't time out on the
+        // combined CGFloat expression (error: "unable to type-check in
+        // reasonable time").
+        let anchorY: CGFloat = (totaHeight - (shortWidth / 2)) / totaHeight
+        let originX: CGFloat = (width / 2) - (totalWidth / 2)
+        let originY: CGFloat = (height / 2) - (totaHeight - (shortWidth / 2))
+        minutesLayer.anchorPoint = CGPoint(x: 0.5, y: anchorY)
+        minutesLayer.frame.origin = CGPoint(x: originX, y: originY)
+
+
         // keep this shadow to differentiate between the minute arm and the hour dots it touches
         minutesLayer.shadowColor = UIColor.black.cgColor
         minutesLayer.shadowOpacity = 0.5
@@ -349,10 +355,16 @@ class ClockView: UIView {
         
         let totaHeight = fittingRect.size.height
         let totalWidth = longWidth
-        
-        hoursLayer.anchorPoint = CGPoint(x: 0.5, y: ((totaHeight - (shortWidth / 2)) / totaHeight))
-        hoursLayer.frame.origin = CGPoint(x: (width / 2) - (totalWidth / 2), y: (height / 2) - (totaHeight - (shortWidth / 2)))
-        
+
+        // Split these out so the Swift type-checker doesn't time out on the
+        // combined CGFloat expression (error: "unable to type-check in
+        // reasonable time").
+        let anchorY: CGFloat = (totaHeight - (shortWidth / 2)) / totaHeight
+        let originX: CGFloat = (width / 2) - (totalWidth / 2)
+        let originY: CGFloat = (height / 2) - (totaHeight - (shortWidth / 2))
+        hoursLayer.anchorPoint = CGPoint(x: 0.5, y: anchorY)
+        hoursLayer.frame.origin = CGPoint(x: originX, y: originY)
+
         hoursLayer.shadowColor = UIColor.black.cgColor
         hoursLayer.shadowOpacity = 0.5
         

--- a/Athan Utility/FajrAlarmManager.swift
+++ b/Athan Utility/FajrAlarmManager.swift
@@ -195,7 +195,17 @@ class FajrAlarmManager {
         let manager = AlarmManager.shared
         let ids = FajrAlarmStore.load()
         var remaining: [UUID] = []
+        var processed = 0
         for id in ids {
+            // Honor cooperative cancellation (e.g. BGTask expired). Persist
+            // the un-processed tail so the next sync pass retries them
+            // instead of leaking orphan alarms.
+            if Task.isCancelled {
+                remaining.append(contentsOf: ids.dropFirst(processed))
+                FajrAlarmStore.save(ids: remaining)
+                return
+            }
+            processed += 1
             do {
                 try manager.cancel(id: id)
             } catch {
@@ -229,7 +239,17 @@ class FajrAlarmManager {
         // next sync can retry them instead of leaking orphans.
         let previous = FajrAlarmStore.load()
         var retained: [UUID] = []
+        var processed = 0
         for id in previous {
+            // Honor cooperative cancellation (e.g. BGTask expired). Persist
+            // the un-processed tail so the next sync pass picks up where
+            // this one left off instead of leaking orphans.
+            if Task.isCancelled {
+                retained.append(contentsOf: previous.dropFirst(processed))
+                FajrAlarmStore.save(ids: retained)
+                return
+            }
+            processed += 1
             do {
                 try manager.cancel(id: id)
             } catch {
@@ -247,6 +267,12 @@ class FajrAlarmManager {
 
         var newIDs: [UUID] = retained
         for date in fireDates {
+            // Honor cooperative cancellation. Persist what we've scheduled
+            // so far; the next sync pass will top up the remaining window.
+            if Task.isCancelled {
+                FajrAlarmStore.save(ids: newIDs)
+                return
+            }
             // Skip past dates defensively.
             guard date > Date() else { continue }
 

--- a/Athan Utility/FajrAlarmManager.swift
+++ b/Athan Utility/FajrAlarmManager.swift
@@ -355,10 +355,14 @@ class FajrAlarmManager {
             countdownDuration = nil
         }
 
+        // Without an explicit sound, AlarmKit schedules a silent alarm.
+        // Pass the system default alarm tone — looping, bypasses silent
+        // switch — which is what a user expects for a wake-up alarm.
         return AlarmManager.AlarmConfiguration(
             countdownDuration: countdownDuration,
             schedule: schedule,
-            attributes: attributes
+            attributes: attributes,
+            sound: .default
         )
     }
     #endif

--- a/Athan Utility/FajrAlarmManager.swift
+++ b/Athan Utility/FajrAlarmManager.swift
@@ -1,0 +1,417 @@
+//
+//  FajrAlarmManager.swift
+//  Athan Utility
+//
+//  Thin wrapper around AlarmKit (iOS 26+) that keeps a rolling set of
+//  scheduled Fajr/Sunrise wake-up alarms in sync with the user's
+//  current prayer-time calculations.
+//
+
+import Foundation
+import CoreLocation
+import Adhan
+#if canImport(AlarmKit)
+import AlarmKit
+import SwiftUI
+#endif
+
+// Metadata attached to each scheduled alarm. Must conform to AlarmMetadata.
+#if canImport(AlarmKit)
+@available(iOS 26.0, *)
+struct FajrAlarmMetadata: AlarmMetadata {
+    let prayerName: String
+    let locationName: String
+    let intendedFireDate: Date
+}
+#endif
+
+// Snapshot of the settings + location state that the async scheduler needs.
+// Captured on the caller's thread so the Task body never reads mutable shared
+// state (AthanManager / FajrAlarmSettings.shared) concurrently.
+private struct FajrSyncSnapshot {
+    let enabled: Bool
+    let target: FajrAlarmTarget
+    let targetDisplayName: String
+    let offsetMinutes: Int
+    let weekdays: FajrAlarmWeekdayMask
+    let snoozeEnabled: Bool
+    let snoozeMinutes: Int
+    let daysAhead: Int
+    let coordinate: CLLocationCoordinate2D
+    let timeZone: TimeZone
+    let locationName: String
+    let adjustments: PrayerAdjustments
+}
+
+// IDs of alarms we scheduled are persisted to the app group so that we can
+// cancel stale alarms on the next sync pass even after the app relaunches.
+private enum FajrAlarmStore {
+    private static let key = "fajralarm.scheduledIDs"
+
+    private static var defaults: UserDefaults {
+        UserDefaults(suiteName: "group.athanUtil") ?? .standard
+    }
+
+    static func save(ids: [UUID]) {
+        defaults.set(ids.map { $0.uuidString }, forKey: key)
+    }
+
+    static func load() -> [UUID] {
+        let raw = defaults.stringArray(forKey: key) ?? []
+        return raw.compactMap { UUID(uuidString: $0) }
+    }
+}
+
+// Platform-agnostic snapshot of AlarmKit authorization state so that view
+// code doesn't need to conditionally import AlarmKit.
+enum FajrAlarmAuthorizationStatus {
+    case unavailable      // iOS < 26 or AlarmKit not present
+    case notDetermined
+    case authorized
+    case denied
+}
+
+class FajrAlarmManager {
+    static let shared = FajrAlarmManager()
+    private init() {}
+
+    // Serial queue that owns all AlarmKit sync work. Prevents two concurrent
+    // sync passes from racing on FajrAlarmStore and leaving orphaned alarms.
+    private let syncQueue = DispatchQueue(label: "com.omaralejel.Athan-Utility.FajrAlarmManager.sync")
+
+    // Snapshot the current authorization state. No system prompt is shown.
+    func currentAuthorizationState() -> FajrAlarmAuthorizationStatus {
+        #if canImport(AlarmKit)
+        if #available(iOS 26.0, *) {
+            switch AlarmManager.shared.authorizationState {
+            case .authorized:    return .authorized
+            case .denied:        return .denied
+            case .notDetermined: return .notDetermined
+            @unknown default:    return .notDetermined
+            }
+        }
+        #endif
+        return .unavailable
+    }
+
+    // Public entry point. Safe to call on any iOS version; no-op pre-26.
+    // Captures settings + location on the caller's thread before dispatching
+    // into the serial sync queue.
+    func syncAlarms() {
+        #if canImport(AlarmKit)
+        if #available(iOS 26.0, *) {
+            guard let snapshot = makeSnapshot() else { return }
+            syncQueue.async {
+                let sem = DispatchSemaphore(value: 0)
+                Task {
+                    await self.syncAlarmsAvailable(snapshot: snapshot)
+                    sem.signal()
+                }
+                sem.wait()
+            }
+        }
+        #endif
+    }
+
+    // Cancels every alarm we previously scheduled. Useful when the user
+    // disables the feature or revokes authorization.
+    func cancelAllManagedAlarms() {
+        #if canImport(AlarmKit)
+        if #available(iOS 26.0, *) {
+            syncQueue.async {
+                let sem = DispatchSemaphore(value: 0)
+                Task {
+                    await self.cancelAllAvailable()
+                    sem.signal()
+                }
+                sem.wait()
+            }
+        }
+        #endif
+    }
+
+    // Asks AlarmKit for authorization if we haven't yet. Returns the final
+    // authorization state via the completion handler on the main thread.
+    func requestAuthorization(completion: @escaping (Bool) -> Void) {
+        #if canImport(AlarmKit)
+        if #available(iOS 26.0, *) {
+            Task {
+                let granted = await requestAuthorizationAvailable()
+                await MainActor.run { completion(granted) }
+            }
+            return
+        }
+        #endif
+        completion(false)
+    }
+
+    // Build a snapshot of everything the scheduler needs, read synchronously
+    // on the caller's thread.
+    private func makeSnapshot() -> FajrSyncSnapshot? {
+        let settings = FajrAlarmSettings.shared
+        settings.sanitize()
+        let athanManager = AthanManager.shared
+        return FajrSyncSnapshot(
+            enabled: settings.enabled,
+            target: settings.target,
+            targetDisplayName: settings.target.displayName,
+            offsetMinutes: settings.offsetMinutes,
+            weekdays: settings.weekdays,
+            snoozeEnabled: settings.snoozeEnabled,
+            snoozeMinutes: settings.snoozeMinutes,
+            daysAhead: settings.daysAhead,
+            coordinate: athanManager.locationSettings.locationCoordinate,
+            timeZone: athanManager.locationSettings.timeZone,
+            locationName: athanManager.locationSettings.locationName,
+            adjustments: athanManager.notificationSettings.adjustments()
+        )
+    }
+
+    // MARK: - iOS 26 implementation
+
+    #if canImport(AlarmKit)
+    @available(iOS 26.0, *)
+    private func requestAuthorizationAvailable() async -> Bool {
+        let manager = AlarmManager.shared
+        switch manager.authorizationState {
+        case .authorized:
+            return true
+        case .denied:
+            return false
+        case .notDetermined:
+            do {
+                let state = try await manager.requestAuthorization()
+                return state == .authorized
+            } catch {
+                print("FajrAlarmManager: authorization request failed: \(error)")
+                return false
+            }
+        @unknown default:
+            return false
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func cancelAllAvailable() async {
+        let manager = AlarmManager.shared
+        let ids = FajrAlarmStore.load()
+        var remaining: [UUID] = []
+        for id in ids {
+            do {
+                try manager.cancel(id: id)
+            } catch {
+                // Couldn't cancel — keep it tracked so we can try again next sync.
+                remaining.append(id)
+            }
+        }
+        FajrAlarmStore.save(ids: remaining)
+    }
+
+    @available(iOS 26.0, *)
+    private func syncAlarmsAvailable(snapshot: FajrSyncSnapshot) async {
+        // If disabled, cancel everything we've scheduled and bail.
+        guard snapshot.enabled else {
+            await cancelAllAvailable()
+            return
+        }
+
+        let authorized = await requestAuthorizationAvailable()
+        guard authorized else {
+            // User hasn't authorized AlarmKit; clean up anything stale.
+            await cancelAllAvailable()
+            return
+        }
+
+        let manager = AlarmManager.shared
+
+        // Always cancel our previously managed alarms before re-scheduling.
+        // AlarmKit does not expose a built-in "replace", so we wipe & rebuild
+        // the rolling window each sync pass. Keep IDs that fail to cancel so
+        // next sync can retry them instead of leaking orphans.
+        let previous = FajrAlarmStore.load()
+        var retained: [UUID] = []
+        for id in previous {
+            do {
+                try manager.cancel(id: id)
+            } catch {
+                retained.append(id)
+            }
+        }
+
+        // Compute the next N firing dates.
+        let fireDates = await upcomingFireDates(snapshot: snapshot)
+
+        // Title is built from a localized format string so Arabic / RTL
+        // languages can rearrange the word order (e.g. "منبّه الفجر").
+        let title = String(format: Strings.fajrAlarmTitleFormat, snapshot.targetDisplayName)
+        let tint = Color(red: 4.0/255.0, green: 65.0/255.0, blue: 125.0/255.0)
+
+        var newIDs: [UUID] = retained
+        for date in fireDates {
+            // Skip past dates defensively.
+            guard date > Date() else { continue }
+
+            let id = UUID()
+            do {
+                let config = try makeConfiguration(
+                    title: title,
+                    locationName: snapshot.locationName,
+                    fireDate: date,
+                    tint: tint,
+                    snoozeEnabled: snapshot.snoozeEnabled,
+                    snoozeMinutes: snapshot.snoozeMinutes,
+                    prayerName: snapshot.targetDisplayName
+                )
+                _ = try await manager.schedule(id: id, configuration: config)
+                newIDs.append(id)
+            } catch {
+                print("FajrAlarmManager: failed to schedule \(date): \(error)")
+            }
+        }
+
+        FajrAlarmStore.save(ids: newIDs)
+    }
+
+    @available(iOS 26.0, *)
+    private func makeConfiguration(
+        title: String,
+        locationName: String,
+        fireDate: Date,
+        tint: Color,
+        snoozeEnabled: Bool,
+        snoozeMinutes: Int,
+        prayerName: String
+    ) throws -> AlarmManager.AlarmConfiguration<FajrAlarmMetadata> {
+
+        // LocalizedStringResource treats its argument as a key that resolves
+        // at display time, so the alarm picks up the user's current system
+        // language even if it changed between scheduling and firing.
+        let stopButton = AlarmButton(
+            text: "Stop",
+            textColor: .white,
+            systemImageName: "stop.circle.fill"
+        )
+
+        let alert: AlarmPresentation.Alert
+        let countdown: AlarmPresentation.Countdown?
+        if snoozeEnabled {
+            let snoozeButton = AlarmButton(
+                text: "Snooze",
+                textColor: .white,
+                systemImageName: "zzz"
+            )
+            alert = AlarmPresentation.Alert(
+                title: LocalizedStringResource(stringLiteral: title),
+                stopButton: stopButton,
+                secondaryButton: snoozeButton,
+                secondaryButtonBehavior: .countdown
+            )
+            // AlarmKit requires a Countdown presentation (and a Live Activity
+            // that renders it) whenever secondaryButtonBehavior is .countdown.
+            // Reuse the stop button so tapping "pause" during a snooze just
+            // ends the alarm — there's no meaningful "pause the snooze" for
+            // a prayer wake-up.
+            countdown = AlarmPresentation.Countdown(
+                title: LocalizedStringResource(stringLiteral: title),
+                pauseButton: stopButton
+            )
+        } else {
+            alert = AlarmPresentation.Alert(
+                title: LocalizedStringResource(stringLiteral: title),
+                stopButton: stopButton
+            )
+            countdown = nil
+        }
+
+        let presentation: AlarmPresentation
+        if let countdown = countdown {
+            presentation = AlarmPresentation(alert: alert, countdown: countdown)
+        } else {
+            presentation = AlarmPresentation(alert: alert)
+        }
+
+        let metadata = FajrAlarmMetadata(
+            prayerName: prayerName,
+            locationName: locationName,
+            intendedFireDate: fireDate
+        )
+
+        let attributes = AlarmAttributes(
+            presentation: presentation,
+            metadata: metadata,
+            tintColor: tint
+        )
+
+        let schedule = Alarm.Schedule.fixed(fireDate)
+
+        // Configure optional snooze countdown duration (in seconds).
+        let countdownDuration: Alarm.CountdownDuration?
+        if snoozeEnabled {
+            countdownDuration = Alarm.CountdownDuration(
+                preAlert: nil,
+                postAlert: TimeInterval(snoozeMinutes * 60)
+            )
+        } else {
+            countdownDuration = nil
+        }
+
+        return AlarmManager.AlarmConfiguration(
+            countdownDuration: countdownDuration,
+            schedule: schedule,
+            attributes: attributes
+        )
+    }
+    #endif
+
+    // MARK: - Fire-date math (plain Swift; no AlarmKit dependency)
+
+    // Returns up to `daysAhead` upcoming alarm fire-dates, respecting the
+    // weekday mask and offset. Uses the Adhan-computed prayer time for the
+    // user's current location/settings. `calculateTimes` is main-isolated
+    // as far as AthanManager's internal state goes, so hop to main before
+    // invoking it.
+    private func upcomingFireDates(snapshot: FajrSyncSnapshot) async -> [Date] {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = snapshot.timeZone
+
+        let now = Date()
+        let startOfToday = cal.startOfDay(for: now)
+
+        var results: [Date] = []
+        // Scan enough days to find daysAhead matching weekdays even if the
+        // weekday mask is sparse (minimum 7 days = whole week).
+        let scanWindow = max(snapshot.daysAhead * 2, 7) + 1
+        for offset in 0..<scanWindow {
+            guard results.count < snapshot.daysAhead else { break }
+
+            guard let day = cal.date(byAdding: .day, value: offset, to: startOfToday) else { continue }
+
+            // Respect weekday filter.
+            let weekday = cal.component(.weekday, from: day) // Sunday == 1
+            guard snapshot.weekdays.containsCalendarWeekday(weekday) else { continue }
+
+            let times = await MainActor.run { () -> PrayerTimes? in
+                return AthanManager.shared.calculateTimes(
+                    referenceDate: day,
+                    customCoordinate: snapshot.coordinate,
+                    customTimeZone: snapshot.timeZone,
+                    adjustments: snapshot.adjustments
+                )
+            }
+            guard let times = times else { continue }
+
+            let base: Date
+            switch snapshot.target {
+            case .fajr:    base = times.fajr
+            case .sunrise: base = times.sunrise
+            }
+            let fireDate = base.addingTimeInterval(TimeInterval(snapshot.offsetMinutes * 60))
+
+            // Skip times already in the past.
+            if fireDate > now {
+                results.append(fireDate)
+            }
+        }
+        return results
+    }
+}

--- a/Athan Utility/FajrAlarmManager.swift
+++ b/Athan Utility/FajrAlarmManager.swift
@@ -26,7 +26,7 @@ struct FajrAlarmMetadata: AlarmMetadata {
 #endif
 
 // Snapshot of the settings + location state that the async scheduler needs.
-// Captured on the caller's thread so the Task body never reads mutable shared
+// Captured on the main actor so the Task body never reads mutable shared
 // state (AthanManager / FajrAlarmSettings.shared) concurrently.
 private struct FajrSyncSnapshot {
     let enabled: Bool
@@ -75,9 +75,14 @@ class FajrAlarmManager {
     static let shared = FajrAlarmManager()
     private init() {}
 
-    // Serial queue that owns all AlarmKit sync work. Prevents two concurrent
-    // sync passes from racing on FajrAlarmStore and leaving orphaned alarms.
-    private let syncQueue = DispatchQueue(label: "com.omaralejel.Athan-Utility.FajrAlarmManager.sync")
+    // Each call to `syncAlarms()` starts a Task that first awaits the previous
+    // Task's completion, producing a strict serial chain. This replaces an
+    // earlier DispatchQueue + DispatchSemaphore implementation — bridging
+    // `DispatchSemaphore.wait()` with `await` is a Swift-Concurrency
+    // anti-pattern (blocks a cooperative thread waiting for a Task) and can
+    // starve the main actor under load.
+    private var latestSync: Task<Void, Never>?
+    private let chainLock = NSLock()
 
     // Snapshot the current authorization state. No system prompt is shown.
     func currentAuthorizationState() -> FajrAlarmAuthorizationStatus {
@@ -95,39 +100,22 @@ class FajrAlarmManager {
     }
 
     // Public entry point. Safe to call on any iOS version; no-op pre-26.
-    // Captures settings + location on the caller's thread before dispatching
-    // into the serial sync queue.
-    func syncAlarms() {
-        #if canImport(AlarmKit)
-        if #available(iOS 26.0, *) {
-            guard let snapshot = makeSnapshot() else { return }
-            syncQueue.async {
-                let sem = DispatchSemaphore(value: 0)
-                Task {
-                    await self.syncAlarmsAvailable(snapshot: snapshot)
-                    sem.signal()
-                }
-                sem.wait()
-            }
+    // Returns a Task that completes when this sync pass (and any queued before
+    // it) finishes — callers that need to await completion (e.g. the
+    // BGAppRefreshTask handler) can `await task.value`; fire-and-forget
+    // callers can ignore the return value thanks to `@discardableResult`.
+    @discardableResult
+    func syncAlarms() -> Task<Void, Never> {
+        chainLock.lock()
+        let previous = latestSync
+        let task = Task { [weak self] in
+            _ = await previous?.value
+            guard !Task.isCancelled else { return }
+            await self?.performSync()
         }
-        #endif
-    }
-
-    // Cancels every alarm we previously scheduled. Useful when the user
-    // disables the feature or revokes authorization.
-    func cancelAllManagedAlarms() {
-        #if canImport(AlarmKit)
-        if #available(iOS 26.0, *) {
-            syncQueue.async {
-                let sem = DispatchSemaphore(value: 0)
-                Task {
-                    await self.cancelAllAvailable()
-                    sem.signal()
-                }
-                sem.wait()
-            }
-        }
-        #endif
+        latestSync = task
+        chainLock.unlock()
+        return task
     }
 
     // Asks AlarmKit for authorization if we haven't yet. Returns the final
@@ -145,11 +133,22 @@ class FajrAlarmManager {
         completion(false)
     }
 
-    // Build a snapshot of everything the scheduler needs, read synchronously
-    // on the caller's thread.
+    private func performSync() async {
+        #if canImport(AlarmKit)
+        if #available(iOS 26.0, *) {
+            guard let snapshot = await makeSnapshot() else { return }
+            await syncAlarmsAvailable(snapshot: snapshot)
+        }
+        #endif
+    }
+
+    // Build a snapshot of everything the scheduler needs. Runs on the main
+    // actor because it reads `FajrAlarmSettings.shared` and `AthanManager`
+    // singleton state that the UI also writes to. Does NOT mutate those
+    // singletons — `sanitize()` is applied at archive/load time instead.
+    @MainActor
     private func makeSnapshot() -> FajrSyncSnapshot? {
         let settings = FajrAlarmSettings.shared
-        settings.sanitize()
         let athanManager = AthanManager.shared
         return FajrSyncSnapshot(
             enabled: settings.enabled,
@@ -283,9 +282,19 @@ class FajrAlarmManager {
         prayerName: String
     ) throws -> AlarmManager.AlarmConfiguration<FajrAlarmMetadata> {
 
-        // LocalizedStringResource treats its argument as a key that resolves
-        // at display time, so the alarm picks up the user's current system
-        // language even if it changed between scheduling and firing.
+        // `AlarmButton.text` is a `LocalizedStringResource`; the bare string
+        // literals below are implicitly promoted to keys that resolve against
+        // `Localizable.strings` at display time. "Stop" and "Snooze" are both
+        // defined in every shipped locale, so the buttons re-localize if the
+        // user switches system language between scheduling and firing.
+        //
+        // The `title` below is different: it's already rendered into the
+        // scheduling-time locale by `String(format:...)` at the call site, so
+        // the alarm's title stays in that language until the rolling window
+        // next refreshes. Rebuilding the title with a parameterized
+        // `LocalizedStringResource` so it re-localizes at display time is a
+        // possible follow-up but requires threading the prayer-name argument
+        // through without losing the Arabic `ال` handling.
         let stopButton = AlarmButton(
             text: "Stop",
             textColor: .white,
@@ -375,6 +384,9 @@ class FajrAlarmManager {
     // as far as AthanManager's internal state goes, so hop to main before
     // invoking it.
     private func upcomingFireDates(snapshot: FajrSyncSnapshot) async -> [Date] {
+        // Empty mask → nothing to schedule. Avoids a pointless full-window scan.
+        guard snapshot.weekdays.raw != 0 else { return [] }
+
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = snapshot.timeZone
 
@@ -382,11 +394,14 @@ class FajrAlarmManager {
         let startOfToday = cal.startOfDay(for: now)
 
         var results: [Date] = []
-        // Scan enough days to find daysAhead matching weekdays even if the
-        // weekday mask is sparse (minimum 7 days = whole week).
-        let scanWindow = max(snapshot.daysAhead * 2, 7) + 1
-        for offset in 0..<scanWindow {
-            guard results.count < snapshot.daysAhead else { break }
+        // Scan enough days to deliver `daysAhead` alarms even when the
+        // weekday mask is sparse (e.g. Sundays only). Worst case is 1 matching
+        // day per 7 calendar days, plus a small buffer for when today's fire
+        // time has already passed.
+        let maxScan = snapshot.daysAhead * 7 + 7
+        var offset = 0
+        while results.count < snapshot.daysAhead, offset < maxScan {
+            defer { offset += 1 }
 
             guard let day = cal.date(byAdding: .day, value: offset, to: startOfToday) else { continue }
 

--- a/Athan Utility/FajrAlarmSettings.swift
+++ b/Athan Utility/FajrAlarmSettings.swift
@@ -1,0 +1,121 @@
+//
+//  FajrAlarmSettings.swift
+//  Athan Utility
+//
+//  Persistent user configuration for the iOS 26 AlarmKit-backed
+//  Fajr/Sunrise wake-up alarm.
+//
+
+import Foundation
+import Adhan
+
+// AlarmKit target: which prayer we anchor the alarm to.
+enum FajrAlarmTarget: Int, Codable, CaseIterable {
+    case fajr = 0
+    case sunrise = 1
+
+    // Equivalent Prayer for reusing existing localized + user-custom names.
+    var prayer: Prayer {
+        switch self {
+        case .fajr:    return .fajr
+        case .sunrise: return .sunrise
+        }
+    }
+
+    // Honors the user's custom prayer-name overrides (same as the rest of the app).
+    var displayName: String {
+        return prayer.localizedOrCustomString()
+    }
+}
+
+// 7-day selection stored as a bitmask. Sunday = 1<<0, ... Saturday = 1<<6.
+// This matches Calendar.current.component(.weekday, ...) with Sunday==1.
+struct FajrAlarmWeekdayMask: Codable, Equatable {
+    var raw: Int
+
+    static let all = FajrAlarmWeekdayMask(raw: 0b1111111)
+    static let empty = FajrAlarmWeekdayMask(raw: 0)
+
+    func isOn(weekdayIndex: Int) -> Bool {
+        // weekdayIndex: 0=Sunday ... 6=Saturday
+        guard weekdayIndex >= 0, weekdayIndex < 7 else { return false }
+        return (raw & (1 << weekdayIndex)) != 0
+    }
+
+    mutating func toggle(weekdayIndex: Int) {
+        guard weekdayIndex >= 0, weekdayIndex < 7 else { return }
+        raw ^= (1 << weekdayIndex)
+    }
+
+    // Convert from Calendar weekday (Sunday==1) to our bitmask index (Sunday==0).
+    func containsCalendarWeekday(_ weekday: Int) -> Bool {
+        return isOn(weekdayIndex: weekday - 1)
+    }
+}
+
+// All user-facing settings for the AlarmKit sync feature.
+class FajrAlarmSettings: Codable, NSCopying {
+
+    static let archiveName = "fajralarmsettings"
+
+    // Enabled master switch.
+    var enabled: Bool = false
+    // Which prayer the alarm is anchored to.
+    var target: FajrAlarmTarget = .fajr
+    // Offset in minutes relative to the target prayer time.
+    // Negative = before target, positive = after target. Clamped to [-120, 120].
+    var offsetMinutes: Int = 0
+    // Days of the week the alarm should fire on.
+    var weekdays: FajrAlarmWeekdayMask = .all
+    // When true, snooze button is shown in the alarm presentation.
+    var snoozeEnabled: Bool = true
+    // Snooze duration in minutes.
+    var snoozeMinutes: Int = 5
+    // Number of days ahead to schedule alarms. AlarmKit supports many, but
+    // keeping this bounded avoids exhausting any system quota.
+    var daysAhead: Int = 7
+
+    init() {}
+
+    // MARK: Shared singleton
+
+    static var shared: FajrAlarmSettings = {
+        if let decoded = checkArchive() {
+            return decoded
+        }
+        return FajrAlarmSettings()
+    }()
+
+    static func checkArchive() -> FajrAlarmSettings? {
+        guard let data = unarchiveData(archiveName) as? Data else { return nil }
+        return try? JSONDecoder().decode(FajrAlarmSettings.self, from: data)
+    }
+
+    static func archive() {
+        let encoder = JSONEncoder()
+        if let data = try? encoder.encode(FajrAlarmSettings.shared) {
+            archiveData(archiveName, object: data)
+        }
+    }
+
+    // Clamp user-adjustable fields to their valid ranges.
+    func sanitize() {
+        offsetMinutes = max(-120, min(120, offsetMinutes))
+        snoozeMinutes = max(1, min(30, snoozeMinutes))
+        daysAhead = max(1, min(14, daysAhead))
+    }
+
+    // MARK: NSCopying
+
+    func copy(with zone: NSZone? = nil) -> Any {
+        let c = FajrAlarmSettings()
+        c.enabled = enabled
+        c.target = target
+        c.offsetMinutes = offsetMinutes
+        c.weekdays = weekdays
+        c.snoozeEnabled = snoozeEnabled
+        c.snoozeMinutes = snoozeMinutes
+        c.daysAhead = daysAhead
+        return c
+    }
+}

--- a/Athan Utility/FajrAlarmSettings.swift
+++ b/Athan Utility/FajrAlarmSettings.swift
@@ -80,10 +80,12 @@ class FajrAlarmSettings: Codable, NSCopying {
     // MARK: Shared singleton
 
     static var shared: FajrAlarmSettings = {
-        if let decoded = checkArchive() {
-            return decoded
-        }
-        return FajrAlarmSettings()
+        let instance = checkArchive() ?? FajrAlarmSettings()
+        // Sanitize once at load time. The scheduler no longer sanitizes on
+        // every read (that would mutate the shared singleton off the main
+        // actor); the UI and saveAndExit handle clamping on write.
+        instance.sanitize()
+        return instance
     }()
 
     static func checkArchive() -> FajrAlarmSettings? {

--- a/Athan Utility/FajrAlarmSettingsView.swift
+++ b/Athan Utility/FajrAlarmSettingsView.swift
@@ -25,6 +25,7 @@ struct FajrAlarmSettingsView: View {
     @State private var snoozeMinutes: Int = 5
     @State private var daysAhead: Int = 7
     @State private var authState: FajrAlarmAuthorizationStatus = .notDetermined
+    @Environment(\.scenePhase) private var scenePhase
 
     private let isOSVersionSupported: Bool = {
         if #available(iOS 26.0, *) { return true } else { return false }
@@ -47,6 +48,15 @@ struct FajrAlarmSettingsView: View {
             header
             scrollBody
             doneButton
+        }
+        // Re-read authorization state whenever we become active — this
+        // catches the case where the user tapped "Open Settings",
+        // flipped the AlarmKit toggle in system Settings, and returned
+        // to the app. `onAppear` alone doesn't fire for that flow.
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .active {
+                authState = FajrAlarmManager.shared.currentAuthorizationState()
+            }
         }
     }
 
@@ -135,6 +145,8 @@ struct FajrAlarmSettingsView: View {
                     Spacer()
                     Stepper("", value: $offsetMinutes, in: -120...120, step: 1)
                         .labelsHidden()
+                        .accessibilityLabel(Text(Strings.fajrAlarmOffset))
+                        .accessibilityValue(Text(offsetDescription))
                 }
 
                 Text(Strings.fajrAlarmOffsetDescription)
@@ -200,6 +212,8 @@ struct FajrAlarmSettingsView: View {
                     Stepper("", value: $snoozeMinutes, in: 1...30, step: 1)
                         .labelsHidden()
                         .disabled(!enabled || !snoozeEnabled || !isOSVersionSupported)
+                        .accessibilityLabel(Text(Strings.fajrAlarmSnooze))
+                        .accessibilityValue(Text(snoozeDescription))
                 }
             }
         }
@@ -217,6 +231,8 @@ struct FajrAlarmSettingsView: View {
                     Stepper("", value: $daysAhead, in: 1...14, step: 1)
                         .labelsHidden()
                         .disabled(!enabled || !isOSVersionSupported)
+                        .accessibilityLabel(Text(Strings.fajrAlarmScheduleWindow))
+                        .accessibilityValue(Text(daysAheadDescription))
                 }
 
                 Text(Strings.fajrAlarmScheduleDescription)
@@ -329,19 +345,24 @@ struct FajrAlarmSettingsView: View {
         s.sanitize()
         FajrAlarmSettings.archive()
 
-        // If enabling the feature, prompt for authorization. syncAlarms()
-        // handles both authorized and denied cases internally.
+        // If enabling the feature, prompt for authorization. `syncAlarms()`
+        // handles both the authorized and denied cases internally (denied
+        // → cancels any stale scheduled alarms). Wait for the auth result
+        // before animating back so that when the user denies we stay on
+        // this screen and render the `deniedBanner`; otherwise a slide-out
+        // transition races the permission sheet and the user never sees
+        // why their alarm isn't firing.
         if enabled && isOSVersionSupported {
             FajrAlarmManager.shared.requestAuthorization { granted in
                 self.authState = granted ? .authorized : .denied
                 FajrAlarmManager.shared.syncAlarms()
+                if granted {
+                    withAnimation { self.activeSection = .General }
+                }
             }
         } else {
             FajrAlarmManager.shared.syncAlarms()
-        }
-
-        withAnimation {
-            activeSection = .General
+            withAnimation { activeSection = .General }
         }
     }
 }

--- a/Athan Utility/FajrAlarmSettingsView.swift
+++ b/Athan Utility/FajrAlarmSettingsView.swift
@@ -1,0 +1,354 @@
+//
+//  FajrAlarmSettingsView.swift
+//  Athan Utility
+//
+//  Settings UI for configuring the iOS 26 AlarmKit-backed Fajr/Sunrise
+//  wake-up alarm.
+//
+
+import SwiftUI
+#if canImport(AlarmKit)
+import AlarmKit
+#endif
+
+@available(iOS 14.0, *)
+struct FajrAlarmSettingsView: View {
+
+    @Binding var activeSection: SettingsSectionType
+
+    // Local copies that are persisted on "Done".
+    @State private var enabled: Bool = false
+    @State private var target: FajrAlarmTarget = .fajr
+    @State private var offsetMinutes: Int = 0
+    @State private var weekdays: FajrAlarmWeekdayMask = .all
+    @State private var snoozeEnabled: Bool = true
+    @State private var snoozeMinutes: Int = 5
+    @State private var daysAhead: Int = 7
+    @State private var authState: FajrAlarmAuthorizationStatus = .notDetermined
+
+    private let isOSVersionSupported: Bool = {
+        if #available(iOS 26.0, *) { return true } else { return false }
+    }()
+
+    // Weekday abbreviations ordered Sunday-first to match FajrAlarmWeekdayMask.
+    private let weekdayAbbreviations: [String] = {
+        let formatter = DateFormatter()
+        return formatter.veryShortStandaloneWeekdaySymbols ?? ["S","M","T","W","T","F","S"]
+    }()
+
+    // Full weekday names (Sunday-first) used for VoiceOver labels.
+    private let weekdayFullNames: [String] = {
+        let formatter = DateFormatter()
+        return formatter.standaloneWeekdaySymbols ?? ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            header
+            scrollBody
+            doneButton
+        }
+    }
+
+    // MARK: - Top-level sub-views
+
+    private var header: some View {
+        Text(Strings.fajrAlarm)
+            .font(.largeTitle)
+            .bold()
+            .foregroundColor(.white)
+            .padding([.leading, .top])
+            .padding([.leading, .top])
+            .onAppear(perform: loadFromSettings)
+    }
+
+    private var scrollBody: some View {
+        ScrollView(showsIndicators: true) {
+            VStack(alignment: .leading, spacing: 16) {
+                if !isOSVersionSupported { unavailableBanner }
+                enableSection
+                offsetSection
+                daysSection
+                snoozeSection
+                scheduleWindowSection
+                if authState == .denied && enabled && isOSVersionSupported {
+                    deniedBanner
+                }
+            }
+            .padding()
+        }
+    }
+
+    private var doneButton: some View {
+        HStack(alignment: .center) {
+            Spacer()
+            Button(action: saveAndExit) {
+                Text(Strings.done)
+                    .foregroundColor(Color(.lightText))
+                    .font(Font.body.weight(.bold))
+            }
+        }
+        .padding()
+        .padding([.leading, .trailing, .bottom])
+    }
+
+    // MARK: - Sections
+
+    private var enableSection: some View {
+        sectionCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Toggle(isOn: $enabled) {
+                    sectionTitle(Strings.enabled)
+                }
+                .disabled(!isOSVersionSupported)
+
+                Text(Strings.fajrAlarmDescription)
+                    .font(.caption)
+                    .foregroundColor(Color(.lightText))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Divider().background(Color.white.opacity(0.3))
+
+                Text(Strings.fajrAlarmAnchorPrayer)
+                    .font(.subheadline).bold().foregroundColor(.white)
+
+                Picker(selection: $target, label: Text(Strings.fajrAlarmAnchorPrayer)) {
+                    ForEach(FajrAlarmTarget.allCases, id: \.rawValue) { t in
+                        Text(t.displayName).tag(t)
+                    }
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .disabled(!enabled || !isOSVersionSupported)
+            }
+        }
+    }
+
+    private var offsetSection: some View {
+        sectionCard {
+            VStack(alignment: .leading, spacing: 8) {
+                sectionTitle(Strings.fajrAlarmOffset)
+
+                HStack {
+                    Text(offsetDescription)
+                        .font(.headline)
+                        .foregroundColor(.white)
+                    Spacer()
+                    Stepper("", value: $offsetMinutes, in: -120...120, step: 1)
+                        .labelsHidden()
+                }
+
+                Text(Strings.fajrAlarmOffsetDescription)
+                    .font(.caption)
+                    .foregroundColor(Color(.lightText))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .disabled(!enabled || !isOSVersionSupported)
+        }
+    }
+
+    private var daysSection: some View {
+        sectionCard {
+            VStack(alignment: .leading, spacing: 8) {
+                sectionTitle(Strings.fajrAlarmDays)
+
+                HStack(spacing: 6) {
+                    ForEach(0..<7, id: \.self) { idx in
+                        weekdayChip(index: idx)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func weekdayChip(index: Int) -> some View {
+        let isOn = weekdays.isOn(weekdayIndex: index)
+        let fullName = weekdayFullNames[safe: index] ?? "?"
+        Button(action: {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            weekdays.toggle(weekdayIndex: index)
+        }) {
+            Text(weekdayAbbreviations[safe: index] ?? "?")
+                .font(.subheadline).bold()
+                .frame(maxWidth: .infinity)
+                .frame(height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .foregroundColor(isOn
+                            ? Color.white.opacity(0.6)
+                            : Color.white.opacity(0.12))
+                )
+                .foregroundColor(isOn ? .black : .white)
+        }
+        .disabled(!enabled || !isOSVersionSupported)
+        .accessibilityLabel(Text(fullName))
+        .accessibilityAddTraits(isOn ? [.isSelected] : [])
+    }
+
+    private var snoozeSection: some View {
+        sectionCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Toggle(isOn: $snoozeEnabled) {
+                    sectionTitle(Strings.fajrAlarmSnooze)
+                }
+                .disabled(!enabled || !isOSVersionSupported)
+
+                HStack {
+                    Text(snoozeDescription)
+                        .font(.headline).foregroundColor(.white)
+                    Spacer()
+                    Stepper("", value: $snoozeMinutes, in: 1...30, step: 1)
+                        .labelsHidden()
+                        .disabled(!enabled || !snoozeEnabled || !isOSVersionSupported)
+                }
+            }
+        }
+    }
+
+    private var scheduleWindowSection: some View {
+        sectionCard {
+            VStack(alignment: .leading, spacing: 8) {
+                sectionTitle(Strings.fajrAlarmScheduleWindow)
+
+                HStack {
+                    Text(daysAheadDescription)
+                        .font(.headline).foregroundColor(.white)
+                    Spacer()
+                    Stepper("", value: $daysAhead, in: 1...14, step: 1)
+                        .labelsHidden()
+                        .disabled(!enabled || !isOSVersionSupported)
+                }
+
+                Text(Strings.fajrAlarmScheduleDescription)
+                    .font(.caption)
+                    .foregroundColor(Color(.lightText))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    // MARK: - Banners and helpers
+
+    @ViewBuilder
+    private func sectionCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .foregroundColor(Color(.sRGB, white: 1, opacity: 0.1))
+            )
+    }
+
+    private func sectionTitle(_ text: String) -> some View {
+        Text(text)
+            .font(.headline)
+            .bold()
+            .foregroundColor(.white)
+    }
+
+    private var unavailableBanner: some View {
+        Text(Strings.fajrAlarmIOS26Required)
+            .font(.footnote)
+            .foregroundColor(.yellow)
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .foregroundColor(Color.yellow.opacity(0.15))
+            )
+    }
+
+    private var deniedBanner: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(Strings.fajrAlarmAuthDenied)
+                .font(.footnote).bold().foregroundColor(.red)
+                .fixedSize(horizontal: false, vertical: true)
+            Button(action: {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }) {
+                Text(Strings.fajrAlarmOpenSettings)
+                    .font(.footnote).foregroundColor(.white).underline()
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .foregroundColor(Color.red.opacity(0.2))
+        )
+    }
+
+    // MARK: - Derived labels
+
+    private var offsetDescription: String {
+        if offsetMinutes == 0 {
+            return String(format: Strings.fajrAlarmOffsetZero, target.displayName)
+        } else if offsetMinutes > 0 {
+            return String(format: Strings.fajrAlarmOffsetAfter, offsetMinutes, target.displayName)
+        } else {
+            return String(format: Strings.fajrAlarmOffsetBefore, abs(offsetMinutes), target.displayName)
+        }
+    }
+
+    private var snoozeDescription: String {
+        String(format: Strings.fajrAlarmSnoozeMinutes, snoozeMinutes)
+    }
+
+    private var daysAheadDescription: String {
+        String(format: Strings.fajrAlarmDaysAhead, daysAhead)
+    }
+
+    // MARK: - Save/load
+
+    private func loadFromSettings() {
+        let s = FajrAlarmSettings.shared
+        enabled = s.enabled
+        target = s.target
+        offsetMinutes = s.offsetMinutes
+        weekdays = s.weekdays
+        snoozeEnabled = s.snoozeEnabled
+        snoozeMinutes = s.snoozeMinutes
+        daysAhead = s.daysAhead
+        authState = FajrAlarmManager.shared.currentAuthorizationState()
+    }
+
+    private func saveAndExit() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+
+        let s = FajrAlarmSettings.shared
+        s.enabled = enabled
+        s.target = target
+        s.offsetMinutes = offsetMinutes
+        s.weekdays = weekdays
+        s.snoozeEnabled = snoozeEnabled
+        s.snoozeMinutes = snoozeMinutes
+        s.daysAhead = daysAhead
+        s.sanitize()
+        FajrAlarmSettings.archive()
+
+        // If enabling the feature, prompt for authorization. syncAlarms()
+        // handles both authorized and denied cases internally.
+        if enabled && isOSVersionSupported {
+            FajrAlarmManager.shared.requestAuthorization { granted in
+                self.authState = granted ? .authorized : .denied
+                FajrAlarmManager.shared.syncAlarms()
+            }
+        } else {
+            FajrAlarmManager.shared.syncAlarms()
+        }
+
+        withAnimation {
+            activeSection = .General
+        }
+    }
+}
+
+// Safe array subscripting.
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Athan Utility/GeneralSettingView.swift
+++ b/Athan Utility/GeneralSettingView.swift
@@ -42,7 +42,24 @@ struct GeneralSettingView: View {
     @State private var isShowingMailView = false
     
     @State var proxy: Any? = nil
-    
+
+    // One-line summary shown on the Fajr Alarm entry row. Reuses the same
+    // localized format strings as the settings screen so Arabic / RTL and
+    // non-Latin minute characters render correctly.
+    private var fajrAlarmSummary: String {
+        let s = FajrAlarmSettings.shared
+        guard s.enabled else { return Strings.fajrAlarmSummaryOff }
+        let offset = s.offsetMinutes
+        let prayer = s.target.displayName
+        if offset == 0 {
+            return String(format: Strings.fajrAlarmOffsetZero, prayer)
+        } else if offset > 0 {
+            return String(format: Strings.fajrAlarmOffsetAfter, offset, prayer)
+        } else {
+            return String(format: Strings.fajrAlarmOffsetBefore, abs(offset), prayer)
+        }
+    }
+
     var body: some View {
         GeometryReader { g in
             VStack(spacing: 0) {
@@ -418,10 +435,58 @@ struct GeneralSettingView: View {
                                         }
                                     }
                                     
+                                    Group { // Fajr alarm (AlarmKit, iOS 26+)
+                                        VStack(alignment: .leading, spacing: 4) {
+                                            Text(Strings.fajrAlarm)
+                                                .font(.headline)
+                                                .bold()
+                                                .foregroundColor(.white)
+                                                .padding(.top)
+                                            Divider()
+                                                .background(Color.white)
+                                        }
+
+                                        Button(action: {
+                                            withAnimation {
+                                                activeSettingsSection = .FajrAlarm
+                                            }
+                                        }, label: {
+                                            HStack {
+                                                Image(systemName: "alarm")
+                                                    .foregroundColor(.white)
+                                                    .font(Font.headline.weight(.bold))
+                                                    .frame(width: 26)
+                                                Text(Strings.fajrAlarm)
+                                                    .font(.headline)
+                                                    .bold()
+                                                    .foregroundColor(.white)
+                                                    .padding(.leading, 2)
+                                                Spacer()
+                                                Text(fajrAlarmSummary)
+                                                    .font(.subheadline)
+                                                    .foregroundColor(Color(.lightText))
+                                                    .lineLimit(1)
+                                                Image(systemName: "chevron.right")
+                                                    .foregroundColor(.white)
+                                                    .font(Font.headline.weight(.bold))
+                                                    .flipsForRightToLeftLayoutDirection(true)
+                                                    .padding()
+                                            }
+                                        })
+                                        .buttonStyle(ScalingButtonStyle())
+
+                                        Text(Strings.fajrAlarmEntryDescription)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                            .lineLimit(nil)
+                                            .font(.caption)
+                                            .foregroundColor(Color(.lightText))
+                                            .padding(.bottom)
+                                    }
+
                                     VStack(spacing: 8) {
                                         Divider()
                                             .background(Color.white)
-                                        
+
                                         IntentIntegratedController()
                                             .frame(height: 50)
                                         Divider()

--- a/Athan Utility/Info.plist
+++ b/Athan Utility/Info.plist
@@ -35,6 +35,12 @@
 	<true/>
 	<key>NSExtensionPointIdentifier</key>
 	<string>com.apple.widgetkit-extension</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.omaralejel.Athan-Utility.fajrAlarmRefresh</string>
+	</array>
+	<key>NSAlarmKitUsageDescription</key>
+	<string>Athan Utility uses AlarmKit to schedule wake-up alarms that stay in sync with your daily Fajr prayer time.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Athan Utility uses your location to calculate athan times. None of your data is shared or stored remotely.</string>
 	<key>NSSiriUsageDescription</key>
@@ -50,6 +56,10 @@
 		<string>GetMaghribIntent</string>
 		<string>GetThuhrIntent</string>
 		<string>NextPrayerIntent</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
 	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>

--- a/Athan Utility/SceneDelegate.swift
+++ b/Athan Utility/SceneDelegate.swift
@@ -171,6 +171,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+
+        // Top up the AlarmKit background-refresh request on backgrounding.
+        // `AppDelegate.applicationDidEnterBackground` is not invoked for
+        // scene-based apps, so this is the reliable hook.
+        (UIApplication.shared.delegate as? AppDelegate)?.scheduleFajrAlarmRefresh()
     }
     
     

--- a/Athan Utility/SettingsView.swift
+++ b/Athan Utility/SettingsView.swift
@@ -12,7 +12,7 @@ import StoreKit
 
 
 enum SettingsSectionType {
-    case General, Sounds, Prayer(Prayer), CalculationMethod, CustomNames, Colors
+    case General, Sounds, Prayer(Prayer), CalculationMethod, CustomNames, Colors, FajrAlarm
 }
 
 @available(iOS 13.0.0, *)
@@ -57,6 +57,9 @@ struct SettingsView: View {
                     .transition(.move(edge: .trailing))
             case .CalculationMethod:
                 CalculationMethodView(tempPrayerSettings: $tempPrayerSettings, viewSelectedMethod: tempPrayerSettings.calculationMethod, activeSection: $activeSection)
+                    .transition(.move(edge: .trailing))
+            case .FajrAlarm:
+                FajrAlarmSettingsView(activeSection: $activeSection)
                     .transition(.move(edge: .trailing))
             }
         }

--- a/Athan Utility/Strings.swift
+++ b/Athan Utility/Strings.swift
@@ -99,4 +99,29 @@ class Strings {
     static var qiblaTurnRight = NSLocalizedString("acc_qibla_turn_right", comment: "Accessibility direction to turn right")
     static var qiblaTurnLeft = NSLocalizedString("acc_qibla_turn_left", comment: "Accessibility direction to turn left")
     static var degreesAbbrev = NSLocalizedString("acc_degrees_abbrev", comment: "Spoken abbreviation for degrees")
+
+    // MARK: - Fajr Alarm (AlarmKit, iOS 26+)
+    static var fajrAlarm = NSLocalizedString("Fajr Alarm", comment: "Feature title")
+    static var fajrAlarmDescription = NSLocalizedString("fajr.alarm.description", comment: "Long description on the Fajr Alarm settings screen")
+    static var fajrAlarmEntryDescription = NSLocalizedString("fajr.alarm.entry.description", comment: "Short description shown beneath the entry row")
+    static var fajrAlarmOffsetDescription = NSLocalizedString("fajr.alarm.offset.description", comment: "Explanation of the offset stepper")
+    static var fajrAlarmScheduleDescription = NSLocalizedString("fajr.alarm.schedule.description", comment: "Explanation of the schedule window stepper")
+    static var fajrAlarmIOS26Required = NSLocalizedString("fajr.alarm.ios26.required", comment: "Shown when the user's iOS version is below 26")
+    static var fajrAlarmAuthDenied = NSLocalizedString("fajr.alarm.authorization.denied", comment: "Shown when the user has denied AlarmKit authorization")
+    static var fajrAlarmSummaryOff = NSLocalizedString("fajr.alarm.summary.off", comment: "Status shown on the entry row when the feature is disabled")
+    static var fajrAlarmAnchorPrayer = NSLocalizedString("Anchor Prayer", comment: "Label for selecting which prayer the alarm is anchored to")
+    static var fajrAlarmOffset = NSLocalizedString("Offset", comment: "Label for the minute offset stepper")
+    static var fajrAlarmDays = NSLocalizedString("Days", comment: "Label for the weekday selector")
+    static var fajrAlarmSnooze = NSLocalizedString("Snooze", comment: "Label for the snooze toggle")
+    static var fajrAlarmScheduleWindow = NSLocalizedString("Schedule Window", comment: "Label for the days-ahead stepper")
+    static var fajrAlarmOpenSettings = NSLocalizedString("Open Settings", comment: "Button to open the system Settings app")
+    // Format string for the alarm presentation title, e.g. "Fajr Alarm" / "منبّه الفجر".
+    // %@ is the localized (or user-custom) prayer name.
+    static var fajrAlarmTitleFormat = NSLocalizedString("fajr.alarm.title.format", comment: "%@ is replaced with the prayer name (Fajr or Sunrise)")
+    // Format strings. Format specifiers must be preserved in translations.
+    static var fajrAlarmOffsetZero = NSLocalizedString("fajr.alarm.offset.zero", comment: "At %@ time — exact offset of zero")
+    static var fajrAlarmOffsetAfter = NSLocalizedString("fajr.alarm.offset.after", comment: "%1$d min after %2$@")
+    static var fajrAlarmOffsetBefore = NSLocalizedString("fajr.alarm.offset.before", comment: "%1$d min before %2$@")
+    static var fajrAlarmSnoozeMinutes = NSLocalizedString("fajr.alarm.snooze.minutes", comment: "%d minute snooze")
+    static var fajrAlarmDaysAhead = NSLocalizedString("fajr.alarm.days.ahead", comment: "%d days ahead")
 }

--- a/Athan Utility/ar.lproj/InfoPlist.strings
+++ b/Athan Utility/ar.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   InfoPlist.strings
   Athan Utility
 
@@ -7,3 +7,6 @@
 */
 
 "CFBundleDisplayName" = "أذان";
+"NSAlarmKitUsageDescription" = "يستخدم تطبيق أذان ميزة AlarmKit لجدولة منبّهات الاستيقاظ التي تبقى متزامنة مع وقت صلاة الفجر اليومي.";
+"NSLocationWhenInUseUsageDescription" = "يستخدم تطبيق أذان موقعك لحساب مواقيت الأذان. لا تتم مشاركة أيٍّ من بياناتك أو تخزينها عن بُعد.";
+"NSSiriUsageDescription" = "يستخدم Siri مواقيت الأذان للمناطق المطلوبة.";

--- a/Athan Utility/ar.lproj/Localizable.strings
+++ b/Athan Utility/ar.lproj/Localizable.strings
@@ -166,3 +166,32 @@
 "Open Athan Utility to set location." = "افتح أداة الأذان لتعيين الموقع";
 "Use Athan Widgets to view upcoming salah times at a glance." = "استخدم أدوات الأذان لعرض أوقات الصلاة القادمة في لمحة.";
 
+
+// MARK: - Fajr Alarm (AlarmKit, iOS 26+)
+"Fajr Alarm" = "منبّه الفجر";
+"fajr.alarm.description" = "يُنشئ منبّهًا حقيقيًا في نظام iOS يتزامن تلقائيًا مع وقت الفجر (أو الشروق) طوال السنة. يتطلّب iOS 26.";
+"fajr.alarm.entry.description" = "اجعل منبّه الآيفون يتتبّع وقت الفجر يوميًا بشكل تلقائي.";
+"fajr.alarm.offset.description" = "اضبط المنبّه ليُنبّهك قبل أو بعد وقت الصلاة المختار. مفيد لقيام الليل أو السحور.";
+"fajr.alarm.schedule.description" = "عدد الأيام القادمة التي يتم جدولة المنبّه لها. يُحدَّث يوميًا.";
+"fajr.alarm.ios26.required" = "يتطلّب منبّه الفجر التلقائي نظام iOS 26 أو أحدث.";
+"fajr.alarm.authorization.denied" = "المنبّهات معطّلة. فعّل صلاحية AlarmKit من إعدادات النظام لاستخدام هذه الميزة.";
+"fajr.alarm.summary.off" = "معطّل";
+"Anchor Prayer" = "الصلاة المرجعية";
+"Offset" = "الإزاحة";
+"Days" = "الأيام";
+"Snooze" = "غفوة";
+"Schedule Window" = "نطاق الجدولة";
+"Stop" = "إيقاف";
+"Open Settings" = "فتح الإعدادات";
+/* Translator note (applies to all four format strings below): the
+   interpolated prayer name in %@ / %2$@ has no leading definite article
+   ("فجر", "شروق"), so the template prepends "ال" to produce "الفجر" /
+   "الشروق". If "Fajr" / "Sunrise" are ever translated to include "ال"
+   already, remove it from these templates to avoid "الال…". */
+"fajr.alarm.title.format" = "منبّه ال%@";
+"fajr.alarm.offset.zero" = "عند وقت ال%@";
+"fajr.alarm.offset.after" = "بعد ال%2$@ بـ %1$d دقيقة";
+"fajr.alarm.offset.before" = "قبل ال%2$@ بـ %1$d دقيقة";
+"fajr.alarm.snooze.minutes" = "غفوة %d دقيقة";
+"fajr.alarm.days.ahead" = "%d أيام مقدّمًا";
+

--- a/Athan Utility/en.lproj/InfoPlist.strings
+++ b/Athan Utility/en.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   InfoPlist.strings
   Athan Utility
 
@@ -6,5 +6,6 @@
   Copyright © 2021 Omar Alejel. All rights reserved.
 */
 
-//NSLocationWhenInUseUsageDescription = "Description of this";
-
+"NSAlarmKitUsageDescription" = "Athan Utility uses AlarmKit to schedule wake-up alarms that stay in sync with your daily Fajr prayer time.";
+"NSLocationWhenInUseUsageDescription" = "Athan Utility uses your location to calculate athan times. None of your data is shared or stored remotely.";
+"NSSiriUsageDescription" = "Athan times for requested regions are used by Siri.";

--- a/Athan Utility/en.lproj/Localizable.strings
+++ b/Athan Utility/en.lproj/Localizable.strings
@@ -212,6 +212,30 @@
 "Athan clock face" = "Athan clock face";
 "Qibla" = "Qibla";
 
+// MARK: - Fajr Alarm (AlarmKit, iOS 26+)
+"Fajr Alarm" = "Fajr Alarm";
+"fajr.alarm.description" = "Schedule a real iOS alarm that stays in sync with Fajr (or Sunrise) as times shift throughout the year. Requires iOS 26.";
+"fajr.alarm.entry.description" = "Automatically keep an iOS alarm locked to Fajr's daily time.";
+"fajr.alarm.offset.description" = "Fire the alarm before or after the chosen prayer. Useful for tahajjud or suhoor.";
+"fajr.alarm.schedule.description" = "Number of upcoming days to keep scheduled. Alarms are refreshed daily.";
+"fajr.alarm.ios26.required" = "Automatic Fajr alarms require iOS 26 or later.";
+"fajr.alarm.authorization.denied" = "Alarms are disabled. Enable AlarmKit access in system Settings to use this feature.";
+"fajr.alarm.summary.off" = "Off";
+"Anchor Prayer" = "Anchor Prayer";
+"Offset" = "Offset";
+"Days" = "Days";
+"Snooze" = "Snooze";
+"Schedule Window" = "Schedule Window";
+"Stop" = "Stop";
+"Open Settings" = "Open Settings";
+"fajr.alarm.title.format" = "%@ Alarm";
+"fajr.alarm.offset.zero" = "At %@ time";
+"fajr.alarm.offset.after" = "%1$d min after %2$@";
+"fajr.alarm.offset.before" = "%1$d min before %2$@";
+"fajr.alarm.snooze.minutes" = "%d minute snooze";
+"fajr.alarm.days.ahead" = "%d days ahead";
+
+
 "Athan Utility stores months of athan data for offline use." = "Athan Utility stores months of athan data for offline use.";
 
 "Get reminded before the next athan takes place. Configurable in app preferences." = "Get reminded before the next athan takes place. Configurable in app preferences.";

--- a/Athan Utility/es.lproj/InfoPlist.strings
+++ b/Athan Utility/es.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   InfoPlist.strings
   Athan Utility
 
@@ -7,3 +7,6 @@
 */
 
 "CFBundleDisplayName" = "Adhan Utility";
+"NSAlarmKitUsageDescription" = "Adhan Utility usa AlarmKit para programar alarmas que se mantienen sincronizadas con tu horario diario de Fajr.";
+"NSLocationWhenInUseUsageDescription" = "Adhan Utility usa tu ubicación para calcular los horarios de adhan. Ninguno de tus datos se comparte ni se almacena de forma remota.";
+"NSSiriUsageDescription" = "Siri utiliza los horarios de adhan para las regiones solicitadas.";

--- a/Athan Utility/es.lproj/Localizable.strings
+++ b/Athan Utility/es.lproj/Localizable.strings
@@ -158,3 +158,27 @@
 // MARK: - Widget
 "Open Athan Utility to set location." = "Abrir Adhan Utility para establecer la ubicación.";
 "Use Athan Widgets to view upcoming salah times at a glance." = "Utilice widgets para ver los próximos momentos de salah de un vistazo.";
+
+
+// MARK: - Fajr Alarm (AlarmKit, iOS 26+)
+"Fajr Alarm" = "Alarma de Fajr";
+"fajr.alarm.description" = "Programa una alarma real de iOS que se mantiene sincronizada con Fajr (o Amanecer) a lo largo del año. Requiere iOS 26.";
+"fajr.alarm.entry.description" = "Mantén automáticamente una alarma de iOS fijada al horario diario de Fajr.";
+"fajr.alarm.offset.description" = "Activa la alarma antes o después de la salah elegida. Útil para tahajjud o suhoor.";
+"fajr.alarm.schedule.description" = "Cantidad de días próximos a mantener programados. Las alarmas se actualizan a diario.";
+"fajr.alarm.ios26.required" = "Las alarmas automáticas de Fajr requieren iOS 26 o posterior.";
+"fajr.alarm.authorization.denied" = "Las alarmas están desactivadas. Activa el acceso a AlarmKit en Ajustes para usar esta función.";
+"fajr.alarm.summary.off" = "Desactivada";
+"Anchor Prayer" = "Salah de referencia";
+"Offset" = "Desplazamiento";
+"Days" = "Días";
+"Snooze" = "Posponer";
+"Schedule Window" = "Ventana de programación";
+"Stop" = "Detener";
+"Open Settings" = "Abrir Ajustes";
+"fajr.alarm.title.format" = "Alarma de %@";
+"fajr.alarm.offset.zero" = "A la hora de %@";
+"fajr.alarm.offset.after" = "%1$d min después de %2$@";
+"fajr.alarm.offset.before" = "%1$d min antes de %2$@";
+"fajr.alarm.snooze.minutes" = "Posponer %d min";
+"fajr.alarm.days.ahead" = "%d días por adelantado";

--- a/Athan Utility/fr.lproj/InfoPlist.strings
+++ b/Athan Utility/fr.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   InfoPlist.strings
   Athan Utility
 
@@ -7,3 +7,6 @@
 */
 
 "CFBundleDisplayName" = "Adhan Utility";
+"NSAlarmKitUsageDescription" = "Adhan Utility utilise AlarmKit pour programmer des alarmes de réveil qui restent synchronisées avec l'heure quotidienne de votre salah de Fejr.";
+"NSLocationWhenInUseUsageDescription" = "Adhan Utility utilise votre position pour calculer les heures d'adhan. Aucune de vos données n'est partagée ni stockée à distance.";
+"NSSiriUsageDescription" = "Les heures d'adhan pour les régions demandées sont utilisées par Siri.";

--- a/Athan Utility/fr.lproj/Localizable.strings
+++ b/Athan Utility/fr.lproj/Localizable.strings
@@ -160,3 +160,27 @@
 "Open Athan Utility to set location." = "Ouvrez l'utilitaire Adhan pour définir l'emplacement.";
 "Use Athan Widgets to view upcoming salah times at a glance." = "Utilisez les widgets Adhan pour afficher les heures de salah à venir en un coup d'œil.";
 
+
+// MARK: - Fajr Alarm (AlarmKit, iOS 26+)
+"Fajr Alarm" = "Alarme Fejr";
+"fajr.alarm.description" = "Planifie une véritable alarme iOS qui reste synchronisée avec Fejr (ou Shuruk) au fil de l'année. Nécessite iOS 26.";
+"fajr.alarm.entry.description" = "Garde automatiquement une alarme iOS calée sur l'heure quotidienne de Fejr.";
+"fajr.alarm.offset.description" = "Déclenche l'alarme avant ou après la salah choisie. Utile pour tahajjud ou suhoor.";
+"fajr.alarm.schedule.description" = "Nombre de jours à venir à programmer. Les alarmes sont rafraîchies chaque jour.";
+"fajr.alarm.ios26.required" = "Les alarmes automatiques Fejr nécessitent iOS 26 ou ultérieur.";
+"fajr.alarm.authorization.denied" = "Les alarmes sont désactivées. Activez l'accès AlarmKit dans les Réglages pour utiliser cette fonction.";
+"fajr.alarm.summary.off" = "Désactivée";
+"Anchor Prayer" = "Salah de référence";
+"Offset" = "Décalage";
+"Days" = "Jours";
+"Snooze" = "Répétition";
+"Schedule Window" = "Fenêtre de programmation";
+"Stop" = "Arrêter";
+"Open Settings" = "Ouvrir Réglages";
+"fajr.alarm.title.format" = "Alarme %@";
+"fajr.alarm.offset.zero" = "À l'heure du %@";
+"fajr.alarm.offset.after" = "%1$d min après %2$@";
+"fajr.alarm.offset.before" = "%1$d min avant %2$@";
+"fajr.alarm.snooze.minutes" = "Répétition de %d min";
+"fajr.alarm.days.ahead" = "%d jours à l'avance";
+

--- a/Athan Utility/tr.lproj/InfoPlist.strings
+++ b/Athan Utility/tr.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   InfoPlist.strings
   Athan Utility
 
@@ -7,3 +7,6 @@
 */
 
 "CFBundleDisplayName" = "Ezan Utility";
+"NSAlarmKitUsageDescription" = "Ezan Utility, günlük Fajr namaz vaktinizle senkronize kalacak uyandırma alarmlarını planlamak için AlarmKit kullanır.";
+"NSLocationWhenInUseUsageDescription" = "Ezan Utility, ezan vakitlerini hesaplamak için konumunuzu kullanır. Verileriniz paylaşılmaz veya uzaktan saklanmaz.";
+"NSSiriUsageDescription" = "İstenen bölgeler için ezan vakitleri Siri tarafından kullanılır.";

--- a/Athan Utility/tr.lproj/Localizable.strings
+++ b/Athan Utility/tr.lproj/Localizable.strings
@@ -159,3 +159,27 @@
 // MARK: - Widget
 "Open Athan Utility to set location." = "Konumu ayarlamak için Ezan Utility'yi açın.";
 "Use Athan Widgets to view upcoming salah times at a glance." = "Yaklaşan namaz vakitlerini bir bakışta görmek için Ezan Widget'larını kullanın.";
+
+
+// MARK: - Fajr Alarm (AlarmKit, iOS 26+)
+"Fajr Alarm" = "Fajr Alarmı";
+"fajr.alarm.description" = "Fajr (veya Shurooq) ile yıl boyunca senkronize kalan gerçek bir iOS alarmı planlar. iOS 26 gerektirir.";
+"fajr.alarm.entry.description" = "Bir iOS alarmını otomatik olarak günlük Fajr vaktine kilitleyin.";
+"fajr.alarm.offset.description" = "Alarmı seçilen namazdan önce veya sonra tetikleyin. Teheccüd veya sahur için kullanışlıdır.";
+"fajr.alarm.schedule.description" = "Planlı tutulacak gün sayısı. Alarmlar her gün yenilenir.";
+"fajr.alarm.ios26.required" = "Otomatik Fajr alarmları için iOS 26 veya sonraki bir sürüm gereklidir.";
+"fajr.alarm.authorization.denied" = "Alarmlar devre dışı. Bu özelliği kullanmak için sistem Ayarları'ndan AlarmKit erişimini etkinleştirin.";
+"fajr.alarm.summary.off" = "Kapalı";
+"Anchor Prayer" = "Referans Namaz";
+"Offset" = "Fark";
+"Days" = "Günler";
+"Snooze" = "Erteleme";
+"Schedule Window" = "Planlama Aralığı";
+"Stop" = "Durdur";
+"Open Settings" = "Ayarları Aç";
+"fajr.alarm.title.format" = "%@ Alarmı";
+"fajr.alarm.offset.zero" = "%@ vaktinde";
+"fajr.alarm.offset.after" = "%2$@'dan %1$d dk sonra";
+"fajr.alarm.offset.before" = "%2$@'dan %1$d dk önce";
+"fajr.alarm.snooze.minutes" = "%d dakika erteleme";
+"fajr.alarm.days.ahead" = "%d gün ileriye";

--- a/Athan Utility/ur.lproj/InfoPlist.strings
+++ b/Athan Utility/ur.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   InfoPlist.strings
   Athan Utility
 
@@ -7,3 +7,6 @@
 */
 
 "CFBundleDisplayName" = "اذان";
+"NSAlarmKitUsageDescription" = "ایتھن یوٹیلیٹی آپ کے روزانہ کے فجر وقت کے ساتھ ہم آہنگ الارم شیڈول کرنے کے لیے AlarmKit استعمال کرتا ہے۔";
+"NSLocationWhenInUseUsageDescription" = "ایتھن یوٹیلیٹی اذان کے اوقات کا حساب لگانے کے لیے آپ کے مقام کا استعمال کرتی ہے۔ آپ کا کوئی بھی ڈیٹا شیئر یا ریموٹ طور پر محفوظ نہیں کیا جاتا۔";
+"NSSiriUsageDescription" = "درخواست کردہ علاقوں کے اذان کے اوقات Siri کے ذریعے استعمال کیے جاتے ہیں۔";

--- a/Athan Utility/ur.lproj/Localizable.strings
+++ b/Athan Utility/ur.lproj/Localizable.strings
@@ -170,3 +170,27 @@
 "Use Athan Widgets to view upcoming salah times at a glance." = "آئندہ سلام کے اوقات کو ایک نظر میں دیکھنے کے لئے اتھن ویجٹ کا استعمال کریں۔";
 
 
+// MARK: - Fajr Alarm (AlarmKit, iOS 26+)
+"Fajr Alarm" = "فجر کا الارم";
+"fajr.alarm.description" = "ایک حقیقی iOS الارم شیڈول کریں جو سال بھر فجر (یا شروق) کے اوقات کے ساتھ خود بخود ہم آہنگ رہتا ہے۔ iOS 26 درکار ہے۔";
+"fajr.alarm.entry.description" = "iOS الارم کو خود بخود روزانہ کے فجر وقت کے ساتھ منسلک رکھیں۔";
+"fajr.alarm.offset.description" = "منتخب کردہ نماز سے پہلے یا بعد میں الارم بجائیں۔ تہجد یا سحری کے لئے مفید۔";
+"fajr.alarm.schedule.description" = "آئندہ کتنے دن تک شیڈول رکھنا ہے۔ الارم روزانہ تازہ کیے جاتے ہیں۔";
+"fajr.alarm.ios26.required" = "خودکار فجر الارم کے لیے iOS 26 یا بعد کا ورژن درکار ہے۔";
+"fajr.alarm.authorization.denied" = "الارم غیر فعال ہیں۔ اس خصوصیت کو استعمال کرنے کے لیے سسٹم سیٹنگز میں AlarmKit کی اجازت فعال کریں۔";
+"fajr.alarm.summary.off" = "بند";
+"Anchor Prayer" = "بنیادی نماز";
+"Offset" = "وقت کا فرق";
+"Days" = "دن";
+"Snooze" = "اسنوز";
+"Schedule Window" = "شیڈول مدت";
+"Stop" = "روکیں";
+"Open Settings" = "سیٹنگز کھولیں";
+"fajr.alarm.title.format" = "%@ کا الارم";
+"fajr.alarm.offset.zero" = "%@ کے وقت پر";
+"fajr.alarm.offset.after" = "%2$@ کے %1$d منٹ بعد";
+"fajr.alarm.offset.before" = "%2$@ سے %1$d منٹ پہلے";
+"fajr.alarm.snooze.minutes" = "%d منٹ اسنوز";
+"fajr.alarm.days.ahead" = "%d دن پہلے سے";
+
+

--- a/Athan Utility/zh-Hans.lproj/InfoPlist.strings
+++ b/Athan Utility/zh-Hans.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   InfoPlist.strings
   Athan Utility
 
@@ -6,5 +6,6 @@
   Copyright © 2021 Omar Alejel. All rights reserved.
 */
 
-//NSLocationWhenInUseUsageDescription = "Description of this";
-
+"NSAlarmKitUsageDescription" = "宣礼 实用工具使用 AlarmKit 安排与您每日晨礼时间保持同步的起床闹钟。";
+"NSLocationWhenInUseUsageDescription" = "宣礼 实用工具使用您的位置来计算宣礼时间。您的任何数据都不会被共享或远程存储。";
+"NSSiriUsageDescription" = "Siri 会使用所请求地区的宣礼时间。";

--- a/Athan Utility/zh-Hans.lproj/Localizable.strings
+++ b/Athan Utility/zh-Hans.lproj/Localizable.strings
@@ -160,3 +160,27 @@
 // MARK: - Widget
 "Open Athan Utility to set location." = "打开 宣礼 实用工具以设置位置。";
 "Use Athan Widgets to view upcoming salah times at a glance." = "使用 宣礼 小部件一目了然地查看即将到来的祷告时间。";
+
+
+// MARK: - Fajr Alarm (AlarmKit, iOS 26+)
+"Fajr Alarm" = "晨礼闹钟";
+"fajr.alarm.description" = "安排一个真正的 iOS 闹钟,使其全年与晨礼(或日出)时间保持同步。需要 iOS 26。";
+"fajr.alarm.entry.description" = "让 iOS 闹钟自动跟随每日晨礼时间。";
+"fajr.alarm.offset.description" = "在所选祷告之前或之后触发闹钟。适用于夜祷或封斋前餐。";
+"fajr.alarm.schedule.description" = "要保持排期的天数。闹钟每日刷新。";
+"fajr.alarm.ios26.required" = "自动晨礼闹钟需要 iOS 26 或更高版本。";
+"fajr.alarm.authorization.denied" = "闹钟已被禁用。请在系统设置中启用 AlarmKit 权限以使用此功能。";
+"fajr.alarm.summary.off" = "已关闭";
+"Anchor Prayer" = "参考祷告";
+"Offset" = "偏移";
+"Days" = "天数";
+"Snooze" = "稍后提醒";
+"Schedule Window" = "排期范围";
+"Stop" = "停止";
+"Open Settings" = "打开设置";
+"fajr.alarm.title.format" = "%@闹钟";
+"fajr.alarm.offset.zero" = "%@ 准时";
+"fajr.alarm.offset.after" = "%2$@ 之后 %1$d 分钟";
+"fajr.alarm.offset.before" = "%2$@ 之前 %1$d 分钟";
+"fajr.alarm.snooze.minutes" = "%d 分钟稍后提醒";
+"fajr.alarm.days.ahead" = "提前 %d 天";

--- a/Athan Widget/AthanWidgetBundle.swift
+++ b/Athan Widget/AthanWidgetBundle.swift
@@ -22,8 +22,13 @@ struct AthanWidgetBundle: WidgetBundle {
 
         // AlarmKit-backed Fajr alarm Live Activity. Required by AlarmKit
         // whenever an alarm uses `secondaryButtonBehavior: .countdown`.
+        // The `#if canImport(AlarmKit)` guard lets the widget target still
+        // compile against older SDKs that don't ship AlarmKit headers; the
+        // runtime `#available` guards usage on the device.
+        #if canImport(AlarmKit)
         if #available(iOS 26.0, *) {
             FajrAlarmLiveActivity()
         }
+        #endif
     }
 }

--- a/Athan Widget/AthanWidgetBundle.swift
+++ b/Athan Widget/AthanWidgetBundle.swift
@@ -12,12 +12,18 @@ import SwiftUI
 @main
 @available(iOS 17.0.0, *)
 struct AthanWidgetBundle: WidgetBundle {
+    @WidgetBundleBuilder
     var body: some Widget {
         Athan_Widget()
         SecondaryAthanWidget()
         TertiaryAthanWidget()
         // Live activities
         SuhoorLiveActivity()
-        
+
+        // AlarmKit-backed Fajr alarm Live Activity. Required by AlarmKit
+        // whenever an alarm uses `secondaryButtonBehavior: .countdown`.
+        if #available(iOS 26.0, *) {
+            FajrAlarmLiveActivity()
+        }
     }
 }

--- a/Athan Widget/Live Activities/SuhoorActivity.swift
+++ b/Athan Widget/Live Activities/SuhoorActivity.swift
@@ -10,6 +10,9 @@ import ActivityKit
 import Foundation
 import SwiftUI
 import WidgetKit
+#if canImport(AlarmKit)
+import AlarmKit
+#endif
 
 
 @available(iOS 16.1, *)
@@ -236,5 +239,73 @@ struct SuhoorLiveActivity: Widget {
             }
         }
     }
-    
+
 }
+
+// MARK: - Fajr Alarm (AlarmKit) Live Activity
+//
+// AlarmKit requires apps that use `secondaryButtonBehavior: .countdown` to
+// register a Live Activity for `AlarmAttributes<FajrAlarmMetadata>` so the
+// system can render the snooze countdown on the Lock Screen, in the Dynamic
+// Island, and in StandBy. The UI is intentionally minimal — AlarmKit drives
+// the actual countdown timer; we just provide labels and a tint.
+
+#if canImport(AlarmKit)
+@available(iOS 26.0, *)
+struct FajrAlarmLiveActivity: Widget {
+    // Matches the tint passed to AlarmAttributes in FajrAlarmManager.
+    private let tint = Color(red: 4.0/255.0, green: 65.0/255.0, blue: 125.0/255.0)
+
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: AlarmAttributes<FajrAlarmMetadata>.self) { context in
+            // Lock screen / banner
+            HStack(spacing: 12) {
+                Image(systemName: "alarm.fill")
+                    .font(.title2)
+                    .foregroundStyle(tint)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(context.attributes.metadata?.prayerName ?? "")
+                        .font(.headline)
+                    if let locationName = context.attributes.metadata?.locationName,
+                       !locationName.isEmpty {
+                        Text(locationName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+            }
+            .padding()
+            .activityBackgroundTint(.black.opacity(0.6))
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "alarm.fill")
+                        .foregroundStyle(tint)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(context.attributes.metadata?.prayerName ?? "")
+                        .font(.headline)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    if let locationName = context.attributes.metadata?.locationName,
+                       !locationName.isEmpty {
+                        Text(locationName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } compactLeading: {
+                Image(systemName: "alarm.fill")
+                    .foregroundStyle(tint)
+            } compactTrailing: {
+                Text(context.attributes.metadata?.prayerName ?? "")
+                    .font(.caption)
+            } minimal: {
+                Image(systemName: "alarm.fill")
+                    .foregroundStyle(tint)
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Assalamu Aleikom, this PR closes #13.

Opt-in iOS 26 AlarmKit-backed wake-up alarm that tracks the daily Fajr (or Sunrise) prayer time with a configurable offset, weekday mask, and snooze. Gracefully no-ops on iOS < 26.

## Feature

- **`FajrAlarmManager`** wraps AlarmKit with authorization, rolling-window cancel + reschedule, and persistence of managed alarm IDs in the app group. Sync work is serialized through a `Task<Void, Never>` chain guarded by `NSLock` so back-to-back syncs (settings change → BG task → foreground) cannot race or leak orphan alarms. Honors `Task.isCancelled` in every loop and persists the un-processed tail so cancellation never drops state.
- **`FajrAlarmSettings`** (`Codable` + `NSCopying`, same shape as the existing settings classes): enable toggle, target (Fajr/Sunrise), minute offset `[-120,120]`, weekday mask, snooze on/off, snooze minutes, schedule window. Sanitized once at archive-load to avoid mutating shared state from a read path.
- **`FajrAlarmSettingsView`**: new SwiftUI screen reachable from General Settings. Surfaces iOS-26 availability, AlarmKit authorization state, and a deep link into system Settings when denied. Observes `scenePhase` so the denied banner clears after the user flips AlarmKit in system Settings and returns. Stepper `accessibilityLabel` + `accessibilityValue` and weekday-chip VoiceOver labels included.
- **General Settings entry row** with a one-line summary that reuses the same `%d`/`%@` format strings as the settings screen, so it respects Arabic / RTL word order and localized minute characters.
- **Sound:** `AlertConfiguration.AlertSound.default` so the alarm actually rings on-device (looping, bypasses the silent switch).
- **Custom prayer-name overrides** are honored — `FajrAlarmTarget.displayName` routes through `Prayer.localizedOrCustomString()`.
- Fire-date math uses the user's timezone (`Calendar.startOfDay`) so the rolling window stays stable across DST and timezone changes.

## Live Activity

`FajrAlarmLiveActivity` registered in `AthanWidgetBundle` with `ActivityConfiguration(for: AlarmAttributes<FajrAlarmMetadata>.self)` — Lock Screen, Dynamic Island (expanded / compact / minimal), and tint. AlarmKit requires this whenever `secondaryButtonBehavior: .countdown` is used. Guarded with `#if canImport(AlarmKit)` + runtime `#available(iOS 26.0, *)` so the widget target still compiles against older SDKs.

## Background refresh

- `BGAppRefreshTask` registered in `AppDelegate.application(_:didFinishLaunchingWithOptions:)` (identifier `com.omaralejel.Athan-Utility.fajrAlarmRefresh`), `using: .main` queue — the handler touches `@Published` `ObservableAthanManager` state and `WidgetCenter`, both main-thread-only.
- Resubmitted on backgrounding from `SceneDelegate.sceneDidEnterBackground`. `applicationDidEnterBackground` is not invoked for scene-based apps (this project uses `UIApplicationSceneManifest`), so it's the reliable hook.
- Handler awaits the sync `Task` before `setTaskCompleted(success: true)`; `expirationHandler` cancels the task and funnels both completion paths through a lock-guarded once-closure so `setTaskCompleted` cannot fire twice.

## Permissions / Info.plist

- `NSAlarmKitUsageDescription` (English + 6 localized variants).
- `BGTaskSchedulerPermittedIdentifiers` with the refresh task ID.
- `UIBackgroundModes += "fetch"`.

## Localization

7 locales updated (ar, en, es, fr, tr, ur, zh-Hans), including a `fajr.alarm.title.format` key so the alarm title (`"Fajr Alarm"` / `"منبّه الفجر"` / `"Alarme Fajr"` / etc.) is built from a localized template instead of runtime string concatenation. Arabic file includes a translator note about the leading `ال` so future edits don't accidentally double-prefix it.

Also localizes the pre-existing `NSLocationWhenInUseUsageDescription` and `NSSiriUsageDescription` entries across ar / es / fr / tr / ur / zh-Hans `InfoPlist.strings` so non-English users get translated permission prompts (previously English-only). Drive-by — happy to split out if you'd prefer.

## Known follow-ups (also from #13)

- **Custom Athan sound** — currently uses the system default. Wiring `AlertConfiguration.AlertSound` to the existing `NotificationSettings.Sounds` enum is straightforward but I left it out to keep this PR scoped. Happy to send as a follow-up.
- **Title re-localization at display time** — button labels (`Stop`, `Snooze`) re-localize via `LocalizedStringResource` keys, but the alarm *title* is rendered into the scheduling-time locale by `String(format:)` and stays in that language until the rolling refresh re-runs (~6h max via the BG task, or sooner on app launch / settings change). Documented inline.

## Drive-by

- `ClockView.swift`: split a multi-CGFloat expression into intermediate locals — Xcode 26's Swift type-checker times out on the original ("unable to type-check in reasonable time"). Pure refactor otherwise.

## Testing

Tested on iPhone 17 Pro running iOS 26. Verified end-to-end: enable → AlarmKit permission prompt → schedule alarms → fire on time → snooze countdown on Lock Screen and Dynamic Island → cancel via toggle → re-schedule on settings change.

## Risk / rollback

All AlarmKit code paths gated by `#if canImport(AlarmKit)` and `@available(iOS 26.0, *)`. Pre-iOS-26 users see a disabled toggle and an explanatory banner. `FajrAlarmSettings` lives in its own `UserDefaults` key in the app group — removing the feature later is just deleting these files; no migration needed. The bundle-identifier sync gate matches the existing convention in `resetWidgets`.

cc @oalejel — let me know if you'd prefer the drive-by InfoPlist localizations or the `ClockView` split into separate PRs, and I'll rebase.